### PR TITLE
We need to make sure that uperf runs on the appropriate system.

### DIFF
--- a/uperf/uperf_run
+++ b/uperf/uperf_run
@@ -68,7 +68,7 @@ ssh_and_check_error()
 
 source .bashrc
 
-client_ip_match=""
+server_match=""
 uperf_version="1.0"
 test_name="uperf"
 rtc=0
@@ -83,7 +83,7 @@ uperf_results=""
 results_file=""
 results_suffix=""
 networks_to_run="1,2,3,4,6,8,12,16,20,24,28,32"
-client_ip_list=""
+server_list=""
 nets=""
 net_count=""
 network_count=""
@@ -129,19 +129,19 @@ usage()
 
 uperf_start_remote()
 {
-	for client in $client_ip_list; do
-		ssh_and_check_error $client "ls /dev > /dev/null"
-		scp -oStrictHostKeyChecking=no ${run_dir}/uperf_build root@$client:${to_home_root}/${to_user}/uperf_build
-		ssh_and_check_error $client "chmod 755 ${to_home_root}/${to_user}/uperf_build"
-		ssh_and_check_error $client "${to_home_root}/${to_user}/uperf_build ${to_home_root} ${to_user}"
+	for server in $server_list; do
+		ssh_and_check_error $server "ls /dev > /dev/null"
+		scp -oStrictHostKeyChecking=no ${run_dir}/uperf_build root@$server:${to_home_root}/${to_user}/uperf_build
+		ssh_and_check_error $server "chmod 755 ${to_home_root}/${to_user}/uperf_build"
+		ssh_and_check_error $server "${to_home_root}/${to_user}/uperf_build ${to_home_root} ${to_user}"
 		#
 		# As firewall section can return error codes that are valid, do not check for errors.
 		#
-		ssh -oStrictHostKeyChecking=no root@$client "systemctl stop firewalld 2> /dev/null"
+		ssh -oStrictHostKeyChecking=no root@$server "systemctl stop firewalld 2> /dev/null"
 		echo Firewall Status: $client
 		echo ==================
-		ssh -oStrictHostKeyChecking=no root@$client "systemctl --no-pager status firewalld"
-		ssh -f -oStrictHostKeyChecking=no root@$client "nohup /usr/local/bin/uperf -s &"
+		ssh -oStrictHostKeyChecking=no root@$server "systemctl --no-pager status firewalld"
+		ssh -f -oStrictHostKeyChecking=no root@$server "nohup /usr/local/bin/uperf -s &"
 	done
 	#
 	# Give it all a chance.
@@ -179,7 +179,7 @@ for arg in "$@"; do
 		# Different test_tools location designated.
 		#
 		tools_git=$arg
-		break;
+		break
 	fi
 	if [[ $arg == "--tools_git" ]]; then
 		found=1
@@ -326,8 +326,8 @@ organize_data()
 	#
 	pushd net_results > /dev/null
 	$TOOLS_BIN/test_header_info --front_matter --results_file $working_dir/results_uperf.csv --host $to_configuration --sys_type $to_sys_type --tuned $to_tuned_setting --results_version $uperf_version --test_name $test_name
-	if [[ $client_ip_match != "" ]]; then
-		echo "# Warning: You are doing a loop back, ip(s) $client_ip_match a local network" >> $working_dir/results_uperf.csv
+	if [[ $server_match != "" ]]; then
+		echo "# Warning: You are doing a loop back, ip(s) $server_match a local network" >> $working_dir/results_uperf.csv
 	fi
 	for tt in `ls`; do
 		pushd $tt > /dev/null
@@ -503,8 +503,8 @@ test_iteration_loop()
 	for test_iteration  in 1 `seq 2 1 $to_times_to_run`;
 	do
 		execute_test $test_iteration
-		for client_ip in $client_ip_list; do
-			ssh -oStrictHostKeyChecking=no $client_ip "pkill -x -9 uperf"
+		for server in $server_list; do
+			ssh -oStrictHostKeyChecking=no $server "pkill -x -9 uperf"
 		done
 		#
 		# Restart uperf on the remote systems.
@@ -538,31 +538,25 @@ njobs_loop()
 	done
 }
 
-client_ip_loop()
+server_ip_loop()
 {
 	local_nets=`ifconfig -a | grep "inet " | awk '{print $2}'`
-	for client_ip in $client_ip_list; do
-		if [[ $local_nets == *"$client_ip"* ]] && [[ $client_ip_match != *"$client_ip"* ]]; then
-			echo Warning: You are doing a loop back, $client_ip is matching a local network 
-			client_ip_match="$client_ip_match $client_ip"
+	for server in $server_list; do
+		if [[ $local_nets == *"$server"* ]] && [[ $server_match != *"$server"* ]]; then
+			echo Warning: You are doing a loop back, $server is matching a local network 
+			server_match="$server_match $server"
 		fi
 		if [[ -z $networks ]]; then
-			networks=$client_ip
+			networks=$server
 			network_count=1
 		else
-			networks+=" "$client_ip
+			networks+=" "$server
 			let "network_count=$network_count+1"
 		fi
 		if [ $network_count -lt $number_networks ]; then
 			continue
 		fi
 		if [ $network_count -gt $number_networks ]; then
-			network_done=1;
-		fi
-		if [ $network_count -gt $number_networks ]; then
-			network_done=1;
-		fi
-		if [ $network_done -eq 1 ]; then
 			break
 		fi
 		njobs_loop
@@ -575,7 +569,7 @@ network_list_loop()
 		if [ $network_done -eq 1 ]; then
 			break
 		fi
-		client_ip_loop
+		server_ip_loop
 	done
 }
 
@@ -744,8 +738,8 @@ if [[ $server_ips == "" ]]; then
 	read server_ips
 fi
 
-client_ip_list=`echo $client_ips | sed 's/,/ /g'`
-server_ip_list=`echo $server_ips | sed 's/,/ /g'`
+client_list=`echo $client_ips | sed 's/,/ /g'`
+server_list=`echo $server_ips | sed 's/,/ /g'`
 
 #
 # We want to make sure the uperf_wrapper are installed on the servers.
@@ -768,13 +762,13 @@ if [ $spawned == 0 ]; then
 	#
 	# Start up uperf on targetd server
 	#
-	for svr in $server_ip_list; do
-		ssh root@$svr "mkdir -p $top_dir"
-		rsync -a $cmd_dir root@$svr:$top_dir
-		rsync -a /root/test_tools root@$svr:/root
-		ssh root@$svr "$0 $arguments --spawned" &
-		 pids[${pindex}]=$!
-		 let "pindex=$pindex+1"
+	for client in $client_list; do
+		ssh root@$client "mkdir -p $top_dir"
+		rsync -a $cmd_dir root@$client:$top_dir
+		rsync -a /root/test_tools root@$client:/root
+		ssh root@$client "$0 $arguments --spawned" &
+		pids[${pindex}]=$!
+		let "pindex=$pindex+1"
 	done
 	#
 	# Wait for everyone to finish
@@ -788,15 +782,15 @@ if [ $spawned == 0 ]; then
 	#
 	mkdir -p export_results
 
-	for svr in $server_ip_list; do
-		dir_to_copy=`ssh root@$svr "ls -rtd /root/export_results/uperf*" | tail -1`
+	for client in $client_list; do
+		dir_to_copy=`ssh root@$client "ls -rtd /root/export_results/uperf*" | tail -1`
 		let "ndir=$ndir+1"
 		direct_export=${direct_export}${separ}${dir_to_copy}
 		if [[ ! -f $dir_to_copy ]]; then
-			rsync -a --ignore-existing root@$svr:$dir_to_copy /root/export_results
+			rsync -a --ignore-existing root@$client:$dir_to_copy /root/export_results
 			cd export_results
-			scp root@$svr:/root/export_results/results_uperf_throughput-performance.tar .
-			scp root@$svr:/tmp/results_uperf.zip /tmp
+			scp root@$client:/root/export_results/results_uperf_throughput-performance.tar .
+			scp root@$client:/tmp/results_uperf.zip /tmp
 			ln -s /root/export_results/results_uperf_throughput-performance.tar /tmp/results_pbench_uperf_throughput-performance.tar
 			ln -s /root/export_results/results_uperf_throughput-performance.tar /tmp/results_uperf_throughput-performance.tar
 		fi
@@ -873,8 +867,8 @@ else
 		save_pbench_results
 	fi
 fi
-for client in $client_ip_list; do
-	ssh -oStrictHostKeyChecking=no root@$client "pkill -x -9 uperf"
+for server in $server_list; do
+	ssh -oStrictHostKeyChecking=no root@$server "pkill -x -9 uperf"
 done
 #
 # Give things a chance to clean up.

--- a/uperf/uperf_run
+++ b/uperf/uperf_run
@@ -31,6 +31,7 @@ if [ ! -f "uperf.out" ]; then
 fi
 
 curdir=`pwd`
+spawned=0
 
 if [[ $0 == "./"* ]]; then
 	chars=`echo $0 | awk -v RS='/' 'END{print NR-1}'`
@@ -67,6 +68,7 @@ ssh_and_check_error()
 
 source .bashrc
 
+client_ip_match=""
 uperf_version="1.0"
 test_name="uperf"
 rtc=0
@@ -99,6 +101,7 @@ client_ips=""
 results_prefix=""
 use_pbench_version=0
 time_delay=0
+njobs=""
 
 #
 # User specific code here.
@@ -126,7 +129,6 @@ usage()
 
 uperf_start_remote()
 {
-	client_ip_list=`echo $client_ips | sed 's/,/ /g'`
 	for client in $client_ip_list; do
 		ssh_and_check_error $client "ls /dev > /dev/null"
 		scp -oStrictHostKeyChecking=no ${run_dir}/uperf_build root@$client:${to_home_root}/${to_user}/uperf_build
@@ -324,6 +326,9 @@ organize_data()
 	#
 	pushd net_results > /dev/null
 	$TOOLS_BIN/test_header_info --front_matter --results_file $working_dir/results_uperf.csv --host $to_configuration --sys_type $to_sys_type --tuned $to_tuned_setting --results_version $uperf_version --test_name $test_name
+	if [[ $client_ip_match != "" ]]; then
+		echo "# Warning: You are doing a loop back, ip(s) $client_ip_match a local network" >> $working_dir/results_uperf.csv
+	fi
 	for tt in `ls`; do
 		pushd $tt > /dev/null
 		for pt in `ls`; do
@@ -499,7 +504,7 @@ test_iteration_loop()
 	do
 		execute_test $test_iteration
 		for client_ip in $client_ip_list; do
-			ssh -oStrictHostKeyChecking=no $client_ip "pkill -9 uperf"
+			ssh -oStrictHostKeyChecking=no $client_ip "pkill -x -9 uperf"
 		done
 		#
 		# Restart uperf on the remote systems.
@@ -528,14 +533,19 @@ packet_type_loop()
 
 njobs_loop()
 {
-	for  njobs in $numb_jobs_do; do
+	for njobs in $numb_jobs_do; do
 		packet_type_loop
 	done
 }
 
 client_ip_loop()
 {
+	local_nets=`ifconfig -a | grep "inet " | awk '{print $2}'`
 	for client_ip in $client_ip_list; do
+		if [[ $local_nets == *"$client_ip"* ]] && [[ $client_ip_match != *"$client_ip"* ]]; then
+			echo Warning: You are doing a loop back, $client_ip is matching a local network 
+			client_ip_match="$client_ip_match $client_ip"
+		fi
 		if [[ -z $networks ]]; then
 			networks=$client_ip
 			network_count=1
@@ -635,6 +645,7 @@ ARGUMENT_LIST=(
 )
 
 NO_ARGUMENTS=(
+	"spawned"
 	"use_pbench_version"
 )
 
@@ -684,6 +695,10 @@ while [[ $# -gt 0 ]]; do
 			server_ips=$value
 			shift 2
 		;;
+		--spawned)
+			spawned=1
+			shift 1
+		;;
 		--suffix)
 			results_suffix=$value
 			shift 2
@@ -728,6 +743,80 @@ if [[ $server_ips == "" ]]; then
 	echo Please designate the client ips
 	read server_ips
 fi
+
+client_ip_list=`echo $client_ips | sed 's/,/ /g'`
+server_ip_list=`echo $server_ips | sed 's/,/ /g'`
+
+#
+# We want to make sure the uperf_wrapper are installed on the servers.
+#
+cmd_dir="/"
+cmd_string=`echo $0 | sed "s/\// /g"`
+for substring in $cmd_string; do
+	cmd_dir=$cmd_dir/$substring
+	if [[ $substring == *"uperf-wrapper"* ]]; then
+		break
+	fi
+done
+top_dir=`echo $cmd_dir | rev | cut -d'/' -f2- | rev`
+if [ $spawned == 0 ]; then
+	declare -a pids
+	direct_export=""
+	separ=""
+	ndirs=0
+	pindex=0
+	#
+	# Start up uperf on targetd server
+	#
+	for svr in $server_ip_list; do
+		ssh root@$svr "mkdir -p $top_dir"
+		rsync -a $cmd_dir root@$svr:$top_dir
+		rsync -a /root/test_tools root@$svr:/root
+		ssh root@$svr "$0 $arguments --spawned" &
+		 pids[${pindex}]=$!
+		 let "pindex=$pindex+1"
+	done
+	#
+	# Wait for everyone to finish
+	#
+	for pid in ${pids[*]}; do
+		wait $pid
+	done
+
+	#
+	# Bring in results if required.
+	#
+	mkdir -p export_results
+
+	for svr in $server_ip_list; do
+		dir_to_copy=`ssh root@$svr "ls -rtd /root/export_results/uperf*" | tail -1`
+		let "ndir=$ndir+1"
+		direct_export=${direct_export}${separ}${dir_to_copy}
+		if [[ ! -f $dir_to_copy ]]; then
+			rsync -a --ignore-existing root@$svr:$dir_to_copy /root/export_results
+			cd export_results
+			scp root@$svr:/root/export_results/results_uperf_throughput-performance.tar .
+			scp root@$svr:/tmp/results_uperf.zip /tmp
+			ln -s /root/export_results/results_uperf_throughput-performance.tar /tmp/results_pbench_uperf_throughput-performance.tar
+			ln -s /root/export_results/results_uperf_throughput-performance.tar /tmp/results_uperf_throughput-performance.tar
+		fi
+	done
+	#
+	# Handle multiple servers.
+	#
+	if [ $ndir -gt 1 ]; then
+		multi_dir=uperf_results_${results_suffix}_$(date "+%Y.%m.%d-%H.%M.%S")
+		mkdir $multi_dir
+		for rdir in $dirct_export; do
+			mv $rdir $multidir
+		done
+		rm -f results_uperf_throughput-performance.tar /tmp/results_${test_name}.zip
+		tar cf results_uperf_throughput-performance.tar $multidir
+		zip /tmp/results_${test_name}.zip  results_${test_name}_${tuned_setting}.tar
+	fi
+	exit
+fi
+
 
 worker=`echo $server_ips | sed "s/,/ /g"`
 number_networks=`echo $worker | wc -w`
@@ -785,7 +874,7 @@ else
 	fi
 fi
 for client in $client_ip_list; do
-	ssh -oStrictHostKeyChecking=no root@$client "pkill -9 uperf"
+	ssh -oStrictHostKeyChecking=no root@$client "pkill -x -9 uperf"
 done
 #
 # Give things a chance to clean up.

--- a/uperf/uperf_run
+++ b/uperf/uperf_run
@@ -451,7 +451,7 @@ execute_test()
 			done
 		fi
 		#
-		# Note: We expext /root to be writeable.  We are unsure at this
+		# Note: We expect /root to be writeable.  We are unsure at this
 		#	time but we might have to use /var/roothome if using
 		#	bootc images.
 		#

--- a/uperf/uperf_run
+++ b/uperf/uperf_run
@@ -31,7 +31,6 @@ if [ ! -f "uperf.out" ]; then
 fi
 
 curdir=`pwd`
-spawned=0
 
 if [[ $0 == "./"* ]]; then
 	chars=`echo $0 | awk -v RS='/' 'END{print NR-1}'`
@@ -66,9 +65,6 @@ ssh_and_check_error()
 	fi
 }
 
-source .bashrc
-
-server_match=""
 uperf_version="1.0"
 test_name="uperf"
 rtc=0
@@ -83,7 +79,8 @@ uperf_results=""
 results_file=""
 results_suffix=""
 networks_to_run="1,2,3,4,6,8,12,16,20,24,28,32"
-server_list=""
+client_ip_list=""
+server_ip_list=""
 nets=""
 net_count=""
 network_count=""
@@ -101,7 +98,6 @@ client_ips=""
 results_prefix=""
 use_pbench_version=0
 time_delay=0
-njobs=""
 
 #
 # User specific code here.
@@ -129,7 +125,7 @@ usage()
 
 uperf_start_remote()
 {
-	for server in $server_list; do
+	for server in $server_ip_list; do
 		ssh_and_check_error $server "ls /dev > /dev/null"
 		scp -oStrictHostKeyChecking=no ${run_dir}/uperf_build root@$server:${to_home_root}/${to_user}/uperf_build
 		ssh_and_check_error $server "chmod 755 ${to_home_root}/${to_user}/uperf_build"
@@ -138,7 +134,7 @@ uperf_start_remote()
 		# As firewall section can return error codes that are valid, do not check for errors.
 		#
 		ssh -oStrictHostKeyChecking=no root@$server "systemctl stop firewalld 2> /dev/null"
-		echo Firewall Status: $client
+		echo Firewall Status: $server
 		echo ==================
 		ssh -oStrictHostKeyChecking=no root@$server "systemctl --no-pager status firewalld"
 		ssh -f -oStrictHostKeyChecking=no root@$server "nohup /usr/local/bin/uperf -s &"
@@ -326,9 +322,6 @@ organize_data()
 	#
 	pushd net_results > /dev/null
 	$TOOLS_BIN/test_header_info --front_matter --results_file $working_dir/results_uperf.csv --host $to_configuration --sys_type $to_sys_type --tuned $to_tuned_setting --results_version $uperf_version --test_name $test_name
-	if [[ $server_match != "" ]]; then
-		echo "# Warning: You are doing a loop back, ip(s) $server_match a local network" >> $working_dir/results_uperf.csv
-	fi
 	for tt in `ls`; do
 		pushd $tt > /dev/null
 		for pt in `ls`; do
@@ -442,6 +435,7 @@ execute_test()
 	net_count=1
 	network_list=`ifconfig -a | grep flags | cut -d: -f1`
 	timestamp=`date +%u%t%T`
+	pindex=0
 
 	for nets in $networks;do
 		build_xml "${njobs}" "${packet_type}" "${packet_size}" "${nets}" "${net_count}" "${network_count}" "1" "${test_case}" "${test_iteration}"
@@ -456,8 +450,12 @@ execute_test()
 				ethtool -S ${nets} > ${uperf_results}/net_stats_${nets}_iter_${test_iteration}.before
 			done
 		fi
-		/usr/local/bin/uperf -m xml${net_count} >> $results_file_worker &
-		pids[${net_count}]=$!
+		for client in $client_ip_list; do
+			scp xml${net_count} root@$client:/root/xml${net_count} > /dev/null
+			ssh -oStrictHostKeyChecking=no root@$client "/usr/local/bin/uperf -m /root/xml${net_count}" >> $results_file_worker &
+			pids[${pindex}]=$!
+			let "pindex=$pindex+1"
+		done 
 		let "net_count=$net_count+1"
 	done
 	# Adjust it down.
@@ -503,8 +501,8 @@ test_iteration_loop()
 	for test_iteration  in 1 `seq 2 1 $to_times_to_run`;
 	do
 		execute_test $test_iteration
-		for server in $server_list; do
-			ssh -oStrictHostKeyChecking=no $server "pkill -x -9 uperf"
+		for client_ip in $server_ip_list; do
+			ssh -oStrictHostKeyChecking=no $client_ip "pkill -x -9 uperf"
 		done
 		#
 		# Restart uperf on the remote systems.
@@ -540,23 +538,21 @@ njobs_loop()
 
 server_ip_loop()
 {
-	local_nets=`ifconfig -a | grep "inet " | awk '{print $2}'`
-	for server in $server_list; do
-		if [[ $local_nets == *"$server"* ]] && [[ $server_match != *"$server"* ]]; then
-			echo Warning: You are doing a loop back, $server is matching a local network 
-			server_match="$server_match $server"
-		fi
+	for server_ip in $server_ip_list; do
 		if [[ -z $networks ]]; then
-			networks=$server
+			networks=$server_ip
 			network_count=1
 		else
-			networks+=" "$server
+			networks+=" "$server_ip
 			let "network_count=$network_count+1"
 		fi
 		if [ $network_count -lt $number_networks ]; then
 			continue
 		fi
 		if [ $network_count -gt $number_networks ]; then
+			network_done=1;
+		fi
+		if [ $network_done -eq 1 ]; then
 			break
 		fi
 		njobs_loop
@@ -639,7 +635,6 @@ ARGUMENT_LIST=(
 )
 
 NO_ARGUMENTS=(
-	"spawned"
 	"use_pbench_version"
 )
 
@@ -689,10 +684,6 @@ while [[ $# -gt 0 ]]; do
 			server_ips=$value
 			shift 2
 		;;
-		--spawned)
-			spawned=1
-			shift 1
-		;;
 		--suffix)
 			results_suffix=$value
 			shift 2
@@ -734,86 +725,13 @@ if [[ $client_ips == "" ]]; then
 	read client_ips
 fi
 if [[ $server_ips == "" ]]; then
-	echo Please designate the client ips
+	echo Please designate the server ips
 	read server_ips
 fi
 
-client_list=`echo $client_ips | sed 's/,/ /g'`
-server_list=`echo $server_ips | sed 's/,/ /g'`
-
-#
-# We want to make sure the uperf_wrapper are installed on the servers.
-#
-cmd_dir="/"
-cmd_string=`echo $0 | sed "s/\// /g"`
-for substring in $cmd_string; do
-	cmd_dir=$cmd_dir/$substring
-	if [[ $substring == *"uperf-wrapper"* ]]; then
-		break
-	fi
-done
-top_dir=`echo $cmd_dir | rev | cut -d'/' -f2- | rev`
-if [ $spawned == 0 ]; then
-	declare -a pids
-	direct_export=""
-	separ=""
-	ndirs=0
-	pindex=0
-	#
-	# Start up uperf on targetd server
-	#
-	for client in $client_list; do
-		ssh root@$client "mkdir -p $top_dir"
-		rsync -a $cmd_dir root@$client:$top_dir
-		rsync -a /root/test_tools root@$client:/root
-		ssh root@$client "$0 $arguments --spawned" &
-		pids[${pindex}]=$!
-		let "pindex=$pindex+1"
-	done
-	#
-	# Wait for everyone to finish
-	#
-	for pid in ${pids[*]}; do
-		wait $pid
-	done
-
-	#
-	# Bring in results if required.
-	#
-	mkdir -p export_results
-
-	for client in $client_list; do
-		dir_to_copy=`ssh root@$client "ls -rtd /root/export_results/uperf*" | tail -1`
-		let "ndir=$ndir+1"
-		direct_export=${direct_export}${separ}${dir_to_copy}
-		if [[ ! -f $dir_to_copy ]]; then
-			rsync -a --ignore-existing root@$client:$dir_to_copy /root/export_results
-			cd export_results
-			scp root@$client:/root/export_results/results_uperf_throughput-performance.tar .
-			scp root@$client:/tmp/results_uperf.zip /tmp
-			ln -s /root/export_results/results_uperf_throughput-performance.tar /tmp/results_pbench_uperf_throughput-performance.tar
-			ln -s /root/export_results/results_uperf_throughput-performance.tar /tmp/results_uperf_throughput-performance.tar
-		fi
-	done
-	#
-	# Handle multiple servers.
-	#
-	if [ $ndir -gt 1 ]; then
-		multi_dir=uperf_results_${results_suffix}_$(date "+%Y.%m.%d-%H.%M.%S")
-		mkdir $multi_dir
-		for rdir in $dirct_export; do
-			mv $rdir $multidir
-		done
-		rm -f results_uperf_throughput-performance.tar /tmp/results_${test_name}.zip
-		tar cf results_uperf_throughput-performance.tar $multidir
-		zip /tmp/results_${test_name}.zip  results_${test_name}_${tuned_setting}.tar
-	fi
-	exit
-fi
-
-
-worker=`echo $server_ips | sed "s/,/ /g"`
-number_networks=`echo $worker | wc -w`
+client_ip_list=`echo $client_ips | sed "s/,/ /g"`
+server_ip_list=`echo $server_ips | sed "s/,/ /g"`
+number_networks=`echo $server_ip_list | wc -w`
 
 #
 # Install epel if RH and then handle locations, else build it.
@@ -867,8 +785,8 @@ else
 		save_pbench_results
 	fi
 fi
-for server in $server_list; do
-	ssh -oStrictHostKeyChecking=no root@$server "pkill -x -9 uperf"
+for client in $server_ip_list; do
+	ssh -oStrictHostKeyChecking=no root@$client "pkill -x -9 uperf"
 done
 #
 # Give things a chance to clean up.

--- a/uperf/uperf_run
+++ b/uperf/uperf_run
@@ -450,6 +450,11 @@ execute_test()
 				ethtool -S ${nets} > ${uperf_results}/net_stats_${nets}_iter_${test_iteration}.before
 			done
 		fi
+		#
+		# Note: We expext /root to be writeable.  We are unsure at this
+		#	time but we might have to use /var/roothome if using
+		#	bootc images.
+		#
 		for client in $client_ip_list; do
 			scp xml${net_count} root@$client:/root/xml${net_count} > /dev/null
 			ssh -oStrictHostKeyChecking=no root@$client "/usr/local/bin/uperf -m /root/xml${net_count}" >> $results_file_worker &
@@ -501,6 +506,10 @@ test_iteration_loop()
 	for test_iteration  in 1 `seq 2 1 $to_times_to_run`;
 	do
 		execute_test $test_iteration
+		#
+		# We need to use the -x option so we only kill off uperf and not
+		# uperf_run also.
+		#
 		for client_ip in $server_ip_list; do
 			ssh -oStrictHostKeyChecking=no $client_ip "pkill -x -9 uperf"
 		done
@@ -785,6 +794,10 @@ else
 		save_pbench_results
 	fi
 fi
+#
+# We need to use the -x option so we only kill off uperf and not
+# uperf_run also.
+#
 for client in $server_ip_list; do
 	ssh -oStrictHostKeyChecking=no root@$client "pkill -x -9 uperf"
 done


### PR DESCRIPTION
Before this change we always run uperf on the system we are running the wrapper on. This may not be the case.  To fix this requires a couple things
1) Make sure uperf wrapper is installed on the system we are suppose
   to be running on.
2) ssh to the system and run the wrapper.  Note we pass an extra
   option --spawned, which tells the uperf wrapper it has been spawned
   by another uperf wrapper and not to spawn again.
3) Once complete, we have make sure we have the results on the system
   we originally started from.
4) Handle multiple invocations of uperf on differing systems.