### PR TITLE
We need to copy /usr/local/bin/uperf to the client system also.

### DIFF
--- a/uperf/uperf_run
+++ b/uperf/uperf_run
@@ -457,6 +457,8 @@ execute_test()
 		#
 		for client in $client_ip_list; do
 			scp xml${net_count} root@$client:/root/xml${net_count} > /dev/null
+			scp  -oStrictHostKeyChecking=no /usr/local/bin/uperf root@$client:/usr/local/bin/uperf
+			ssh_and_check_error $client "chmod 755 /usr/local/bin/uperf"
 			ssh -oStrictHostKeyChecking=no root@$client "/usr/local/bin/uperf -m /root/xml${net_count}" >> $results_file_worker &
 			pids[${pindex}]=$!
 			let "pindex=$pindex+1"


### PR DESCRIPTION
We need to copy /usr/loca/bin/uperf to the client system

Issue #34 
RPOPC: https://issues.redhat.com/browse/RPOPC-291