### PR TITLE
Create uperf dir

### DIFF
--- a/uperf/uperf_build
+++ b/uperf/uperf_build
@@ -2,6 +2,7 @@
 
 install_uperf()
 {
+	mkdir -p /$1/$2/workloads/uperf_run
 	cd /$1/$2/workloads/uperf_run
 	git clone https://github.com/uperf/uperf.git uperf
 	cd uperf

--- a/uperf/uperf_build
+++ b/uperf/uperf_build
@@ -2,7 +2,9 @@
 
 install_uperf()
 {
-	mkdir -p /$1/$2/workloads/uperf_run
+	if [[ ! -d /$1/$2/workloads/uperf_run ]]; then
+		mkdir -p /$1/$2/workloads/uperf_run
+	fi
 	cd /$1/$2/workloads/uperf_run
 	git clone https://github.com/uperf/uperf.git uperf
 	cd uperf


### PR DESCRIPTION
# Description
Private Cloud amis, uperf is failing because the uperf_run directory is missing.  This checks to see if the directory exists, if not it creates it.

# Before/After Comparison
Before
uperf_build fails when we have to build uperf.

After
uperf_build successfully runs

# Clerical Stuff
Issue: #37 

Relates to JIRA: RPOPC-<TICKET_NUMBER>
