### PR TITLE
Reformat Summary CSV file

### DIFF
--- a/uperf/uperf_run
+++ b/uperf/uperf_run
@@ -268,6 +268,7 @@ record_data()
 	echo Instance_Count:trans_sec >> iops.csv
 	create_header $1 $2 $3 $4 Bandwidth Gb_sec throughput.csv
 	echo Instance_Count:GB_Sec >> throughput.csv
+	echo "Instance_Count:GB_Sec:trans_sec:lat_usec:test_type:packet_type:packet_size" > $working_dir/results_uperf.csv
 	#
 	# Now populate the files
 	#
@@ -281,13 +282,11 @@ record_data()
 		echo $threads:$bw:$rest >> throughput.csv
 		echo $threads:$iops:$rest >> iops.csv
 		echo $threads:$lat:$rest >> latency.csv
+		echo $threads:$bw:$iops:$lat:$rest >> $working_dir/results_uperf.csv
 	done < "${work_file}.sorted"
 	echo "" >> throughput.csv
 	echo "" >> iops.csv
 	echo "" >> latency.csv
-	cat throughput.csv >> $working_dir/results_uperf.csv
-	cat iops.csv >> $working_dir/results_uperf.csv
-	cat latency.csv >> $working_dir/results_uperf.csv
 	rm ${work_file}*
 }
 


### PR DESCRIPTION
# Description
This commit changes the results summary file to be a well-formatted csv file.  Previously the summary csv was missing test_type, packet_type and packet_size headers, and there are multiple tables embedded to handle throughput, iops and latency.  This adds the missing headers, and consolidates throughput, iops and latency into the same table.  This is to help with CSV to JSON conversion.

# Before/After Comparison
## Before
CSV looked like this
| Instance Count | GB_sec/trans_sec/usec |  |  |  |
|--------|--------|--------|--------|--------|
| 1 | 5.0 | stream | tcp | 16384 |

## After
CSV is formatted like this

| Instance Count | GB_sec |  trans_sec | lat_usec  |  test_type| packet_type | packet_size |
|------------------------|------------|----------------|--------------|---------------|--------------------|---|
| 1 | 5.0 | 16500 |  0.0 | stream | tcp | 16384 |

# Clerical Stuff
This closes #45 
Relates to JIRA: RPOPC-585
