### PR TITLE
One scp command isn't turning off strict host key checking

### DIFF
--- a/uperf/uperf_run
+++ b/uperf/uperf_run
@@ -456,7 +456,7 @@ execute_test()
 		#	bootc images.
 		#
 		for client in $client_ip_list; do
-			scp xml${net_count} root@$client:/root/xml${net_count} > /dev/null
+			scp -oStrictHostKeyChecking=no xml${net_count} root@$client:/root/xml${net_count} > /dev/null
 			scp  -oStrictHostKeyChecking=no /usr/local/bin/uperf root@$client:/usr/local/bin/uperf
 			ssh_and_check_error $client "chmod 755 /usr/local/bin/uperf"
 			ssh -oStrictHostKeyChecking=no root@$client "/usr/local/bin/uperf -m /root/xml${net_count}" >> $results_file_worker &


### PR DESCRIPTION
# Description
Fixes an issue where the scp command to copy the generated xml file does not turn off strict host key checking.  This means any host that hasn't been seen already (e.g. newly created cloud instances) will get stuck asking the user if they should continue, a message the user can never see and never respond to, and the benchmark gets hung before it ever gets started.  Adding `-o StrictHostKeyChecking=no` skips this check and the command continues and the run completes.

# Before/After Comparison
Before: the wrapper would hang indefinitely, and a ps tree listing would show it's stuck in the 'scp xml1' command.
After: the benchmark run finishes successfully.

# Clerical Stuff
Relates to JIRA: RPOPC-583
This closes #43 