### PR TITLE
Fix uperf erasing prior information in results_uperf.csv

### DIFF
--- a/uperf/uperf_run
+++ b/uperf/uperf_run
@@ -266,7 +266,12 @@ record_data()
 	echo Instance_Count:trans_sec >> iops.csv
 	create_header $1 $2 $3 $4 Bandwidth Gb_sec throughput.csv
 	echo Instance_Count:GB_Sec >> throughput.csv
-	echo "Instance_Count:GB_Sec:trans_sec:lat_usec:test_type:packet_type:packet_size" > $working_dir/results_uperf.csv
+	#
+	# We want to append to the file, not overwrite it.  If we over write the file,
+	# we will lose the prior metadata header as well as prior test information written
+	# to it.
+	#
+	echo "Instance_Count:GB_Sec:trans_sec:lat_usec:test_type:packet_type:packet_size" >> $working_dir/results_uperf.csv
 	#
 	# Now populate the files
 	#


### PR DESCRIPTION
# Description
Restores results_uperf.csv so it contains the entire run information and meta data, and not just the last data point.

# Before/After Comparison
Before:  results_uperf.csv contained only the last data point
After: results_uperf.csv contains the meta_data and all run information as expected.

# Clerical Stuff
This closes #50 

Relates to JIRA: RPOPC-630
