### PR TITLE
Adding test pcp metric, timestamps, replace colon with comma in resul…

### DIFF
--- a/uperf/openmetrics_uperf_reset.txt
+++ b/uperf/openmetrics_uperf_reset.txt
@@ -7,12 +7,12 @@ latency NaN
 streams_test NaN
 rr_test NaN
 biderec_test NaN
-maerts NaN
-numb_networks NaN
-tcp_packet NaN
-udp_packet NaN
+maerts_test NaN
+num_networks NaN
+is_tcp NaN
+is_udp NaN
 packet_size NaN
-number_procs NaN
+num_threads NaN
 Gb_Sec NaN
 trans_sec NaN
 lat_usec NaN

--- a/uperf/uperf_run
+++ b/uperf/uperf_run
@@ -228,7 +228,7 @@ create_header()
 	test_type=$1
 	packet_type=$2
 	packet_size=$3
-	numb_nets=$4
+	num_nets=$4
 	top_title=$5
 	y_title=$6
 	out_file=$7
@@ -248,7 +248,7 @@ record_data()
 		start_time=`grep ^Start_time $file | awk '{print $2}'`
 		end_time=`grep ^End_time  $file | awk '{print $2}'`
 		echo $file
-		protocal=`echo $file | cut -d'_' -f3 | cut -d'=' -f 2`
+		protocol=`echo $file | cut -d'_' -f3 | cut -d'=' -f 2`
 		op_type=`echo $file | cut -d'_' -f5 | cut -d'=' -f 2`
 		packet_size=`echo $file | cut -d'_' -f6 | cut -d'=' -f 2`
 		threads=`echo $file | cut -d'_' -f 4 | cut -d'=' -f 2`
@@ -268,7 +268,7 @@ record_data()
 		op1=`echo $ops | sed "s/op\/s//g"`
 		latency=`echo "scale=6;1/${op1}" | bc`
 		
-		echo "${threads},${time},$rate,$ops,$latency,${protocal},${op_type},${packet_size},${start_time},${end_time}" >> $work_file
+		echo "${threads},${time},$rate,$ops,$latency,${protocol},${op_type},${packet_size},${start_time},${end_time}" >> $work_file
 	done
 	cat $work_file | sort -n > ${work_file}.sorted
 	#
@@ -280,8 +280,8 @@ record_data()
 	#
 	create_header $1 $2 $3 $4 Latency usec latency.csv
 #	echo number_procs,usec,Start_Date,End_Date >> latency.csv
-	create_header $1 $2 $3 $4 Transaction/second trans_sec iops.csv
-#	echo number_procs,trans_sec,Start_Date,End_Date >> iops.csv
+	create_header $1 $2 $3 $4 Transaction/second trans_sec pps.csv
+#	echo number_procs,trans_sec,Start_Date,End_Date >> pps.csv
 	create_header $1 $2 $3 $4 Bandwidth Gb_sec throughput.csv
 #	echo number_procs,Gb_Sec,Start_Date,End_Date >> throughput.csv
 	#
@@ -302,20 +302,20 @@ record_data()
 		f8=`echo $line | cut -d, -f 8`
 		start_time=`echo $line | cut -d, -f 9`
 		end_time=`echo $line | cut -d, -f 10`
-		iops=`echo $line | cut -d, -f 4 | sed "s/op\/s//g"`
+		pps=`echo $line | cut -d, -f 4 | sed "s/op\/s//g"`
 		lat=`echo $line | cut -d, -f 5`
 		out_string=$(build_data_string  "${threads}" "${bw}" "${f6}" "${f7}' ${f8}" "${start_time}" "${end_time}")
 		echo $out_string >> throughput.csv
-		out_string=$(build_data_string  "${threads}" "${iops}" "$rest}" "${start_time}" "${end_time}")
-		echo $out_string >> iops.csv
+		out_string=$(build_data_string  "${threads}" "${pps}" "$rest}" "${start_time}" "${end_time}")
+		echo $out_string >> pps.csv
 		out_string=$(build_data_string  "${threads}" "${lat}" "${rest}" "${start_time}" "${end_time}")
 		echo $out_string >> lat.csv
-		out_string=$(build_data_string  "${threads}" "${bw}" "${iops}" "${lat}" "${f6}" "${f7}" "${f8}" "${start_time}" "${end_time}")
+		out_string=$(build_data_string  "${threads}" "${bw}" "${pps}" "${lat}" "${f6}" "${f7}" "${f8}" "${start_time}" "${end_time}")
 		echo $out_string >> $working_dir/results_uperf.csv
 	done < "${work_file}.sorted"
 	cat $working_dir/results_uperf.csv
 	echo "" >> throughput.csv
-	echo "" >> iops.csv
+	echo "" >> pps.csv
 	echo "" >> latency.csv
 	rm ${work_file}*
 }
@@ -328,7 +328,7 @@ organize_data()
 	test_type=`ls summary_results_* | cut -d'_' -f 3 | sort -u`
 	packet_type=`ls summary_results_* | cut -d'_' -f 5 | sort -u | cut -d'=' -f 2`
 	packet_size=`ls summary_results_* | cut -d'_' -f 6 | sort -u | cut -d'=' -f 2`
-	numb_nets=`ls summary_results_* | cut -d'_' -f 7 | sort -u | cut -d'=' -f 2`
+	num_nets=`ls summary_results_* | cut -d'_' -f 7 | sort -u | cut -d'=' -f 2`
 	#
 	# First make the heirchy and cp the appropriate files there.
 	#
@@ -338,7 +338,7 @@ organize_data()
 	for tt in $test_type; do
 		for pt in $packet_type; do
 			for ps in $packet_size; do
-				for nn in $numb_nets; do
+				for nn in $num_nets; do
 					mkdir -p net_results/${tt}/${pt}/${ps}/${nn}
 					cp summary_results_${tt}*pt=${pt}_ps=${ps}_nets=${nn}_iteration* net_results/${tt}/${pt}/${ps}/${nn}
 				done
@@ -375,7 +375,7 @@ organize_data()
 build_xml()
 {
 	local_nthr=$1
-	local_protocal=$2
+	local_protocol=$2
 	local_pk_size=$3
 	local_test_host=$4
 	local_instance=$5
@@ -390,7 +390,7 @@ build_xml()
 	case $local_test_type in
 		rr)
 			echo "    <transaction iterations=\"1\">" >> xml${local_instance}
-			echo "      <flowop type=\"connect\" options=\"remotehost=${local_test_host} protocol=${local_protocal}\"/>" >> xml${local_instance}
+			echo "      <flowop type=\"connect\" options=\"remotehost=${local_test_host} protocol=${local_protocol}\"/>" >> xml${local_instance}
 			echo "    </transaction>" >> xml${local_instance}
 			echo "    <transaction duration=\"${execution_time}s\">" >> xml${local_instance}
 			echo "      <flowop type=\"write\" options=\"count=${local_nthr} size=${local_pk_size}\"/>" >> xml${local_instance}
@@ -401,7 +401,7 @@ build_xml()
 		;;
 		stream|bidirec)
 			echo "    <transaction iterations=\"1\">" >> xml${local_instance}
-			echo "      <flowop type=\"connect\" options=\"remotehost=${local_test_host} protocol=${local_protocal}\"/>" >> xml${local_instance}
+			echo "      <flowop type=\"connect\" options=\"remotehost=${local_test_host} protocol=${local_protocol}\"/>" >> xml${local_instance}
 			echo "    </transaction>" >> xml${local_instance}
 			echo "    <transaction duration=\"${execution_time}s\">" >> xml${local_instance}
 			echo "      <flowop type=\"write\" options=\"count=${local_nthr} size=${local_pk_size}\"/>" >> xml${local_instance}
@@ -412,7 +412,7 @@ build_xml()
 			;;
 		maerts|bidirec)
 			echo "    <transaction iterations=\"1\">" >> xml${local_instance}
-			echo "      <flowop type=\"accept\" options=\"remotehost=${local_test_host} protocol=${local_protocal}\"/>" >> xml${local_instance}
+			echo "      <flowop type=\"accept\" options=\"remotehost=${local_test_host} protocol=${local_protocol}\"/>" >> xml${local_instance}
 			echo "    </transaction>" >> xml${local_instance}
 			echo "    <transaction duration=\"${execution_time}s\">" >> xml${local_instance}
 			echo "      <flowop type=\"read\" options=\"${local_nthr} size=${local_pk_size}\"/>" >> xml${local_instance}
@@ -425,7 +425,7 @@ build_xml()
 	echo "  </group>" >> xml${local_instance}
 	echo "</profile>" >> xml${local_instance}
 
-	results_file="results_${local_test_type}_nj=${local_nthr}_pt=${local_protocal}_ps=${local_pk_size}_nets=${local_numb_networks}_iteration=${local_test_iteration}"
+	results_file="results_${local_test_type}_nj=${local_nthr}_pt=${local_protocol}_ps=${local_pk_size}_nets=${local_numb_networks}_iteration=${local_test_iteration}"
 	if [ ${local_instance} -eq 1 ]; then
 		results_file_worker="${results_file}_itera=${local_iteration}.${local_instance}_${results_suffix}"
 	else
@@ -460,7 +460,7 @@ report_pcp_values()
 {
 	results=`grep ^Total $1`
 	file=`echo "${1}" | rev | cut -d'/' -f1 | rev`
-	protocal=`echo $file | cut -d'_' -f3 | cut -d'=' -f 2`
+	protocol=`echo $file | cut -d'_' -f3 | cut -d'=' -f 2`
 	op_type=`echo $file | cut -d'_' -f5 | cut -d'=' -f 2`
 	packet_size=`echo $file | cut -d'_' -f6 | cut -d'=' -f 2`
 	threads=`echo $file | cut -d'_' -f 4 | cut -d'=' -f 2`
@@ -505,13 +505,13 @@ execute_test()
 			elif [[ $test_case == "bidirec" ]]; then
 				results2pcp_add_value "biderec_test:1"
 			else
-				results2pcp_add_value "maerts:1"
+				results2pcp_add_value "maert_tests:1"
 			fi
-			results2pcp_add_value "numb_networks:${net_count}"
-			if [[ $op_type == "packet_type" ]]; then
-				results2pcp_add_value "tcp_packet:1"
+			results2pcp_add_value "num_networks:${net_count}"
+			if [[ $packet_type == "tcp" ]]; then
+				results2pcp_add_value "is_tcp:1"
 			else
-				results2pcp_add_value "udp_packet:1"
+				results2pcp_add_value "is_udp:1"
 			fi
 			results2pcp_add_value "packet_size:$packet_size"
 			results2pcp_add_value_commit


### PR DESCRIPTION
# Description
1) Adds timestamps to the csv file
2) Replaces colon with comma in the csv file
3) Saves the test results into pcp

# Before/After Comparison
Before:  No timestamps in csv file, and test metrics not in openmetrics file
After: Timestamps present in the csv file, and test metrics present in openmetrics.

# Clerical Stuff
This closes #54 


Relates to JIRA: RPOPC-789

Test Results

Test command executed
/home/ec2-user/workloads/uperf-wrapper-2.1/uperf/uperf_run --run_user ec2-user --home_parent /home --iterations 1 --tuned_setting tuned_none_sys_file_ --host_config "m5.xlarge" --sysname "m5.xlarge" --sys_type aws  --use_pcp  --client_ips 10.0.25.101 --server_ips 10.0.25.100 --tests stream,rr --numb_jobs 1,8,16 --packet_type tcp --packet_sizes 64,16384 --time 60 --debug

csv file
umber_procs,Gb_Sec,trans_sec,lat_usec,test_type,packet_type,packet_size,Start_Date,End_Date
1,1.90,14512,.000068,stream,tcp,16384,2026-02-04T19:31:59Z,2026-02-04T19:33:02Z
8,1.90,14524,.000068,stream,tcp,16384,2026-02-04T19:35:36Z,2026-02-04T19:36:39Z
16,1.90,14524,.000068,stream,tcp,16384,2026-02-04T19:39:13Z,2026-02-04T19:40:16Z

number_procs,Gb_Sec,trans_sec,lat_usec,test_type,packet_type,packet_size,Start_Date,End_Date
1,.53,1065481,0,stream,tcp,64,2026-02-04T19:30:10Z,2026-02-04T19:31:14Z
8,1.27,2480057,0,stream,tcp,64,2026-02-04T19:33:48Z,2026-02-04T19:34:51Z
16,1.28,2499814,0,stream,tcp,64,2026-02-04T19:37:24Z,2026-02-04T19:38:28Z


pcp output (snippet)

          o.w.iteration  o.w.running  o.w.numthreads  o.w.runtime  o.w.throughput  o.w.latency  o.w.streams_test  o.w.rr_test  o.w.biderec_test  o.w.maerts_test  o.w.is_tcp  o.w.is_udp  o.w.packet_size  o.w.Gb_Sec  o.w.trans_sec  o.w.lat_usec  o.w.num_networks  o.w.num_threads
19:31:14          1.000        1.000           0.000          NaN             NaN          NaN             1.000          NaN               NaN              NaN       1.000         NaN           64.000       0.530    1065481.000         0.000             1.000              NaN
19:31:15          1.000        1.000           0.000          NaN             NaN          NaN             1.000          NaN               NaN              NaN       1.000         NaN           64.000       0.530    1065481.000         0.000             1.000              NaN
19:33:03          1.000        1.000           0.000          NaN             NaN          NaN             1.000          NaN               NaN              NaN       1.000         NaN        16384.000       1.900      14512.000         0.000             1.000              NaN
19:33:04          1.000        1.000           0.000          NaN             NaN          NaN             1.000          NaN               NaN              NaN       1.000         NaN        16384.000       1.900      14512.000         0.000             1.000              NaN
19:34:51          1.000        1.000           0.000          NaN             NaN          NaN             1.000          NaN               NaN              NaN       1.000         NaN           64.000       1.270    2480057.000         0.000             1.000              NaN
19:34:52          1.000        1.000           0.000          NaN             NaN          NaN             1.000          NaN               NaN              NaN       1.000         NaN           64.000       1.270    2480057.000         0.000             1.000              NaN
19:36:40          1.000        1.000           0.000          NaN             NaN          NaN             1.000          NaN               NaN              NaN       1.000         NaN        16384.000       1.900      14524.000         0.000             1.000              NaN
19:36:41          1.000        1.000           0.000          NaN             NaN          NaN             1.000          NaN               NaN              NaN       1.000         NaN        16384.000       1.900      14524.000         0.000             1.000              NaN
19:38:28          1.000        1.000           0.000          NaN             NaN          NaN             1.000          NaN               NaN              NaN       1.000         NaN           64.000       1.280    2499814.000         0.000             1.000              NaN
19:38:29          1.000        1.000           0.000          NaN             NaN          NaN             1.000          NaN               NaN              NaN       1.000         NaN           64.000       1.280    2499814.000         0.000             1.000              NaN
19:40:17          1.000        1.000           0.000          NaN             NaN          NaN             1.000          NaN               NaN              NaN       1.000         NaN        16384.000       1.900      14524.000         0.000             1.000              NaN
19:40:18          1.000        1.000           0.000          NaN             NaN          NaN             1.000          NaN               NaN              NaN       1.000         NaN        16384.000       1.900      14524.000         0.000             1.000              NaN




-x output
[uperf_out.txt](https://github.com/user-attachments/files/25080795/uperf_out.txt)


