### PR TITLE
Add validation of results and fix TOOLS_BIN

### DIFF
--- a/uperf/schemas/lat
+++ b/uperf/schemas/lat
@@ -2,10 +2,11 @@ import pydantic
 import datetime
 
 class Uperf_Results(pydantic.BaseModel):
-    number_procs: int = pydantic.Field(gt=0)
+    instances: int = pydantic.Field(gt=0)
     Latency_usec: float = pydantic.Field(ge=0, allow_inf_nan=False)
     test: str
-    packet: str
+    packet_type: str
     packet_size: int = pydantic.Field(gt=0)
     Start_Date: datetime.datetime
     End_Date: datetime.datetime
+

--- a/uperf/schemas/pps
+++ b/uperf/schemas/pps
@@ -2,10 +2,10 @@ import pydantic
 import datetime
 
 class Uperf_Results(pydantic.BaseModel):
-    number_procs: int = pydantic.Field(gt=0)
+    instances: int = pydantic.Field(gt=0)
     trans_sec: int = pydantic.Field(gt=0)
     test: str
-    packet: str
+    packet_type: str
     packet_size: int = pydantic.Field(gt=0)
     Start_Date: datetime.datetime
     End_Date: datetime.datetime

--- a/uperf/schemas/throughput
+++ b/uperf/schemas/throughput
@@ -2,10 +2,10 @@ import pydantic
 import datetime
 
 class Uperf_Results(pydantic.BaseModel):
-    number_procs: int = pydantic.Field(gt=0)
+    instances: int = pydantic.Field(gt=0)
     Bandwidth_Gb_sec: float = pydantic.Field(ge=0, allow_inf_nan=False)
     test: str
-    packet: str
+    packet_type: str
     packet_size: int = pydantic.Field(gt=0)
     Start_Date: datetime.datetime
     End_Date: datetime.datetime

--- a/uperf/uperf_run
+++ b/uperf/uperf_run
@@ -245,7 +245,7 @@ create_header()
 	y_title=$6
 	out_file=$7
 
-	echo number_procs,"${top_title}"_"${y_title}",test,packet,packet_size,Start_Date,End_Date >> $out_file
+	echo instances,"${top_title}"_"${y_title}",test,packet_type,packet_size,Start_Date,End_Date >> $out_file
 }
 
 record_data()
@@ -293,7 +293,7 @@ record_data()
 	# we will lose the prior metadata header as well as prior test information written
 	# to it.
 	#
-	echo "number_procs,Gb_Sec,trans_sec,lat_usec,test_type,packet_type,packet_size,Start_Date,End_Date" >> $working_dir/results_uperf.csv
+	echo "instances,Gb_Sec,trans_sec,lat_usec,test_type,packet_type,packet_size,Start_Date,End_Date" >> $working_dir/results_uperf.csv
 	#
 	# Now populate the files
 	#


### PR DESCRIPTION
# Description
Adds validation of results, and standardizes how TOOLS_BIN is created

# Before/After Comparison
Before: results where not verified
After: results are verified

# Clerical Stuff
This closes #56 

Relates to JIRA: RPOPC-827

Testing

Command executed
/home/ec2-user/workloads/uperf-wrapper-2.2/uperf/uperf_run --run_user ec2-user --home_parent /home --iterations 1 --tuned_setting tuned_none_sys_file_ --host_config "m7i.xlarge" --sysname "m7i.xlarge" --sys_type aws  --use_pcp  --client_ips 10.0.25.101 --server_ips 10.0.25.100 --tests stream,rr --numb_jobs 1,8,16 --packet_type tcp --packet_sizes 64,16384 --time 60 --use_pcp --debug

succesful run
Unit firewalld.service could not be found.
/tmp/uperf_results__2026.02.13-10.13.01 /home/ec2-user
Results verified
Results verified
Results verified
Results verified
Results verified
Results verified
/home/ec2-user
updating: results_uperf_virtual-guest.tar (deflated 94%)

[root@ip-170-0-19-213 ec2-user]# echo $?
0

csv file
number_procs,Gb_Sec,trans_sec,lat_usec,test_type,packet_type,packet_size,Start_Date,End_Date
1,4.78,36474,.000027,stream,tcp,16384,2026-02-12T21:31:24Z,2026-02-12T21:32:27Z
8,11.95,91203,.000010,stream,tcp,16384,2026-02-12T21:34:58Z,2026-02-12T21:36:01Z
16,11.95,91204,.000010,stream,tcp,16384,2026-02-12T21:38:33Z,2026-02-12T21:39:36Z

number_procs,Gb_Sec,trans_sec,lat_usec,test_type,packet_type,packet_size,Start_Date,End_Date
1,1.38,2702272,0,stream,tcp,64,2026-02-12T21:29:37Z,2026-02-12T21:30:40Z
8,3.06,5981024,0,stream,tcp,64,2026-02-12T21:33:12Z,2026-02-12T21:34:14Z
16,3.14,6123753,0,stream,tcp,64,2026-02-12T21:36:46Z,2026-02-12T21:37:49Z


induced failure
Could not verify schema, see below for details
3 validation errors for list[Uperf_Results]
0.trans_sec
  Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='2711147f', input_type=str]
    For further information visit https://errors.pydantic.dev/2.12/v/int_parsing1.trans_sec
  Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='6028092f', input_type=str]
    For further information visit https://errors.pydantic.dev/2.12/v/int_parsing2.trans_sec
  Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='6108337f', input_type=str]
    For further information visit https://errors.pydantic.dev/2.12/v/int_parsing
Failure in /tmp/uperf_results__2026.02.12-19.08.39/net_results/stream/tcp/64/1 pps.csv
/workloads/uperf-wrapper-2.2/uperf/schemas/
Could not verify schema, see below for details
3 validation errors for list[Uperf_Results]
0.Bandwidth_Gb_sec
  Input should be a valid number, unable to parse string as a number [type=float_parsing, input_value='1.39f', input_type=str]
    For further information visit https://errors.pydantic.dev/2.12/v/float_parsing
1.Bandwidth_Gb_sec
  Input should be a valid number, unable to parse string as a number [type=float_parsing, input_value='3.09f', input_type=str]
    For further information visit https://errors.pydantic.dev/2.12/v/float_parsing
2.Bandwidth_Gb_sec
  Input should be a valid number, unable to parse string as a number [type=float_parsing, input_value='3.13f', input_type=str]
    For further information visit https://errors.pydantic.dev/2.12/v/float_parsing
Failure in /tmp/uperf_results__2026.02.12-19.08.39/net_results/stream/tcp/64/1 throughput.csv
/home/ec2-user
updating: results_uperf_virtual-guest.tar (deflated 94%)
[root@ip-170-0-19-213 ec2-user]# echo $?
1

--debug output
[uperf_out.txt](https://github.com/user-attachments/files/25288160/uperf_out.txt)


