### PR TITLE
Add missing rhel package net-tools

### DIFF
--- a/uperf/uperf.json
+++ b/uperf/uperf.json
@@ -15,6 +15,7 @@
             "gcc",
             "lksctp-tools-devel",
             "bc",
+            "net-tools",
             "zip",
             "unzip",
             "git"


### PR DESCRIPTION
# Description
Adds a missing package in for rhel

# Before/After Comparison
Before:   Command ifconfig is missing, which the missing command handler catches.
After: Command ifconfig is present, and everything is happy.

# Clerical Stuff
This closes #58 


Relates to JIRA: RPOPC-840

Testing
Command executed
Success
This system is not registered with an entitlement server. You can use "rhc" or "subscription-manager" to register.
Last metadata expiration check: 0:21:54 ago on Tue 17 Feb 2026 08:24:31 PM UTC.
No match for argument: epel-release.noarch
Error: Unable to find a match: epel-release.noarch
Firewall Status: 10.0.25.100

Unit firewalld.service could not be found.
/tmp/uperf_results__2026.02.17-20.25.19 /home/ec2-user
summary_results_rr_nj=16_pt=tcp_ps=16384_nets=1_iteration=1_
summary_results_rr_nj=1_pt=tcp_ps=16384_nets=1_iteration=1_
summary_results_rr_nj=8_pt=tcp_ps=16384_nets=1_iteration=1_
test_type: rr

number_procs,Gb_Sec,trans_sec,lat_usec,test_type,packet_type,packet_size,Start_Date,End_Date
1,1.35,2645387,0,stream,tcp,64,2026-02-17T20:25:31Z,2026-02-17T20:26:35Z
8,3.11,6070607,0,stream,tcp,64,2026-02-17T20:29:07Z,2026-02-17T20:30:10Z
16,3.11,6071541,0,stream,tcp,64,2026-02-17T20:32:42Z,2026-02-17T20:33:45Z


Failed command
Warning: The unit file, source configuration file or drop-ins of PCPrecord.service changed on disk. Run 'systemctl daemon-reload' to reload units.
Start PCP
PCP metrics reset
PCP Start Complete
Firewall status

Unit firewalld.service could not be found.
Error: The command "ifconfig" was not found.

