### PR TITLE
Update how we load test_tools

### DIFF
--- a/uperf/uperf_run
+++ b/uperf/uperf_run
@@ -202,13 +202,44 @@ fi
 
 TOOLS_BIN="${HOME}/test_tools"
 export TOOLS_BIN
-if [ ! -d "${TOOLS_BIN}" ]; then
-	git clone $tools_git ${TOOLS_BIN}
-	if [ $? -ne 0 ]; then
-		echo pulling git $tools_git failed.
-		exit 101
-	fi
-fi
+
+attempt_tools_wget()
+{
+        if [[ ! -d "$TOOLS_BIN" ]]; then
+                wget ${tools_git}/archive/refs/heads/main.zip
+                if [[ $? -eq 0 ]]; then
+                        unzip -q main.zip
+                        mv test_tools-wrappers-main ${TOOLS_BIN}
+                        rm main.zip
+                fi
+        fi
+}
+
+attempt_tools_curl()
+{
+        if [[ ! -d "$TOOLS_BIN" ]]; then
+                curl -L -O ${tools_git}/archive/refs/heads/main.zip
+                if [[ $? -eq 0 ]]; then
+                        unzip -q main.zip
+                        mv test_tools-wrappers-main ${TOOLS_BIN}
+                        rm main.zip
+                fi
+        fi
+}
+
+attempt_tools_git()
+{
+        if [[ ! -d "$TOOLS_BIN" ]]; then
+                git clone $tools_git "$TOOLS_BIN"
+                if [ $? -ne 0 ]; then
+                        exit_out "Error: pulling git $tools_git failed." 101
+                fi
+        fi
+}
+
+attempt_tools_wget
+attempt_tools_curl
+attempt_tools_git
 source ${TOOLS_BIN}/error_codes
 ${TOOLS_BIN}/gather_data ${curdir}
 source ${TOOLS_BIN}/general_setup "$@"


### PR DESCRIPTION
# Description
Uses the new way of getting test_tools

# Before/After Comparison
Before: We only used git, if git was not present, we would fail.
After: We now try git, curl and wget.

# Clerical Stuff
This closes #61 

Relates to JIRA: RPOPC-878

Testing done
Ran the following scenario file
global:
  ssh_key_file: replace_your_ssh_key
  terminate_cloud: 1
  os_vendor: rhel
  results_prefix: uperf_results
  os_vendor: rhel
  system_type: aws
  cloud_os_id: ami-035032ea878eca201
systems:
  system1:
    tests: "uperf"
    host_config: "m5.xlarge:Networks;number=1"

csv file produced
instances,Gb_Sec,trans_sec,lat_usec,test_type,packet_type,packet_size,Start_Date,End_Date
1,1.80,13707,.000072,rr,tcp,16384,2026-03-16T09:27:25Z,2026-03-16T09:28:28Z
8,10.77,82172,.000012,rr,tcp,16384,2026-03-16T09:31:02Z,2026-03-16T09:32:05Z
16,10.17,77628,.000012,rr,tcp,16384,2026-03-16T09:34:39Z,2026-03-16T09:35:42Z

instances,Gb_Sec,trans_sec,lat_usec,test_type,packet_type,packet_size,Start_Date,End_Date
1,.01,38647,.000025,rr,tcp,64,2026-03-16T09:25:36Z,2026-03-16T09:26:39Z
8,.0008,1693,.000590,rr,tcp,64,2026-03-16T09:29:13Z,2026-03-16T09:30:16Z
16,0,6394,.000156,rr,tcp,64,2026-03-16T09:32:50Z,2026-03-16T09:33:53Z

instances,Gb_Sec,trans_sec,lat_usec,test_type,packet_type,packet_size,Start_Date,End_Date
1,9.18,70041,.000014,stream,tcp,16384,2026-03-16T09:16:34Z,2026-03-16T09:17:37Z
8,9.58,73108,.000013,stream,tcp,16384,2026-03-16T09:20:11Z,2026-03-16T09:21:14Z
16,9.60,73226,.000013,stream,tcp,16384,2026-03-16T09:23:48Z,2026-03-16T09:24:51Z

instances,Gb_Sec,trans_sec,lat_usec,test_type,packet_type,packet_size,Start_Date,End_Date
1,.50,1014179,0,stream,tcp,64,2026-03-16T09:14:45Z,2026-03-16T09:15:48Z
8,1.25,2442130,0,stream,tcp,64,2026-03-16T09:18:22Z,2026-03-16T09:19:25Z
16,1.25,2448401,0,stream,tcp,64,2026-03-16T09:21:59Z,2026-03-16T09:23:02Z

