### PR TITLE
use ${to_pkg_tool_flags}" instead of --no_packages $to_no_pkg_install

### DIFF
--- a/uperf/uperf.json
+++ b/uperf/uperf.json
@@ -12,6 +12,8 @@
             "unzip"
         ],
         "rhel": [
+            "autoconf",
+            "automake",
             "gcc",
             "lksctp-tools-devel",
             "bc",

--- a/uperf/uperf_run
+++ b/uperf/uperf_run
@@ -238,7 +238,7 @@ source $TOOLS_BIN/helpers.inc
 #
 # Install packages
 #
-package_tool --wrapper_config ${run_dir}/uperf.json --no_packages $to_no_pkg_install
+package_tool --wrapper_config ${run_dir}/uperf.json
 if [[ $? -ne 0 ]]; then
 	echo Package installation using ${TOOLS_BIN}/package_tool was unsuccessful.
 	exit $E_PACKAGE_TOOL_PACKAGING
@@ -689,7 +689,7 @@ client_package_install()
 	fi
 	scp -oStrictHostKeyChecking=no test_tools.tar root@$lc_client:${to_home_root}/${to_user}/test_tools.tar
 	scp -oStrictHostKeyChecking=no  ${run_dir}/uperf.json  root@$lc_client:${to_home_root}/${to_user}/uperf.json
-	ssh_and_check_error $lc_client "cd ${to_home_root}/${to_user}; tar xf test_tools.tar;${tools_dir}/package_tool --wrapper_config uperf.json --no_packages $to_no_pkg_install"
+	ssh_and_check_error $lc_client "cd ${to_home_root}/${to_user}; tar xf test_tools.tar;${tools_dir}/package_tool --wrapper_config uperf.json ${to_pkg_tool_flags}"
 	popd > /dev/null
 }
 


### PR DESCRIPTION
# Description
Fixes package to to install properly based on $to_no_pkg_install

# Before/After Comparison
Before: Private amis  with no package loading fails
After: Private amis with no package loading produces data.

# Clerical Stuff
This closes #65 



Relates to JIRA: RPOPC-934

Testing
Verified that uperf works properly in private amis
instances,Gb_Sec,trans_sec,lat_usec,test_type,packet_type,packet_size,Start_Date,End_Date
1,1.61,12281,.000081,rr,tcp,16384,2026-04-21T10:43:03Z,2026-04-21T10:44:07Z
8,10.79,82304,.000012,rr,tcp,16384,2026-04-21T10:46:38Z,2026-04-21T10:47:42Z
16,10.19,77752,.000012,rr,tcp,16384,2026-04-21T10:50:13Z,2026-04-21T10:51:17Z

